### PR TITLE
fix: vitest infinite recursion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,17 @@ function replaceAnsiCodes(str: string): string {
 const ansiSerializer: SnapshotSerializer = {
   serialize(val, config, indentation, depth, refs, printer) {
     const newValue = replaceAnsiCodes(val);
-    return printer(newValue, config, indentation, depth, refs);
+    // TODO (43081j): maybe there's a way to not do this?
+    // `printer` will call this plugin recursively since the `test` below
+    // will always pass for a string.
+    // Ideally, the `test` would test that this is a string we haven't already
+    // processed. You can't just test for ANSI codes though, as we may not
+    // replace all of them so would still enter recursion hell.
+    const newConfig = {
+      ...config,
+      plugins: config.plugins.filter((plugin) => plugin !== ansiSerializer)
+    };
+    return printer(newValue, newConfig, indentation, depth, refs);
   },
   test(val) {
     return typeof val === 'string';

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -6,8 +6,9 @@ type NewSnapshotSerializer = Exclude<SnapshotSerializer, {print: unknown}>;
 
 const serializer = ansiSerializer as NewSnapshotSerializer;
 
-const mockConfig: Parameters<NewSnapshotSerializer['serialize']>[1] =
-  {} as never;
+const mockConfig: Parameters<NewSnapshotSerializer['serialize']>[1] = {
+  plugins: []
+} as never;
 const toString = (val: unknown) => String(val);
 const basicSerialize = (input: unknown) =>
   serializer.serialize(input, mockConfig, '', 0, [], toString);


### PR DESCRIPTION
vitest calls plugins with `printer`, a function which itself calls plugins.

Since our plugin `test` will be forever true for strings, this means we will infinitely call ourselves by calling `printer`.

To avoid this, we remove ourselves from the plugin list.